### PR TITLE
Add Pangolin API foundation

### DIFF
--- a/Pango.xcodeproj/project.pbxproj
+++ b/Pango.xcodeproj/project.pbxproj
@@ -12,7 +12,18 @@
 
 /* Begin PBXFileReference section */
 		4346E59E2E40713F00CD1A93 /* Pango.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pango.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000012E50000000C0D001 /* PangoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PangoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXContainerItemProxy section */
+		A10000022E50000000C0D001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4346E5962E40713F00CD1A93 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4346E59D2E40713F00CD1A93;
+			remoteInfo = Pango;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
 		43EDD7482E4B8B3C00CD23B3 /* Exceptions for "Pango" folder in "Pango" target */ = {
@@ -33,6 +44,11 @@
 			path = Pango;
 			sourceTree = "<group>";
 		};
+		A10000032E50000000C0D001 /* PangoTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PangoTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -44,6 +60,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A10000042E50000000C0D001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -51,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				4346E5A02E40713F00CD1A93 /* Pango */,
+				A10000032E50000000C0D001 /* PangoTests */,
 				4346E59F2E40713F00CD1A93 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -59,6 +83,7 @@
 			isa = PBXGroup;
 			children = (
 				4346E59E2E40713F00CD1A93 /* Pango.app */,
+				A10000012E50000000C0D001 /* PangoTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -89,6 +114,29 @@
 			productReference = 4346E59E2E40713F00CD1A93 /* Pango.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A10000052E50000000C0D001 /* PangoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000062E50000000C0D001 /* Build configuration list for PBXNativeTarget "PangoTests" */;
+			buildPhases = (
+				A10000072E50000000C0D001 /* Sources */,
+				A10000042E50000000C0D001 /* Frameworks */,
+				A10000082E50000000C0D001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A10000092E50000000C0D001 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A10000032E50000000C0D001 /* PangoTests */,
+			);
+			name = PangoTests;
+			packageProductDependencies = (
+			);
+			productName = PangoTests;
+			productReference = A10000012E50000000C0D001 /* PangoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -101,6 +149,10 @@
 				TargetAttributes = {
 					4346E59D2E40713F00CD1A93 = {
 						CreatedOnToolsVersion = 16.4;
+					};
+					A10000052E50000000C0D001 = {
+						CreatedOnToolsVersion = 26.0;
+						TestTargetID = 4346E59D2E40713F00CD1A93;
 					};
 				};
 			};
@@ -123,12 +175,20 @@
 			projectRoot = "";
 			targets = (
 				4346E59D2E40713F00CD1A93 /* Pango */,
+				A10000052E50000000C0D001 /* PangoTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		4346E59C2E40713F00CD1A93 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A10000082E50000000C0D001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -145,7 +205,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A10000072E50000000C0D001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A10000092E50000000C0D001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4346E59D2E40713F00CD1A93 /* Pango */;
+			targetProxy = A10000022E50000000C0D001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		4346E5A72E40714000CD1A93 /* Debug */ = {
@@ -339,6 +414,38 @@
 			};
 			name = Release;
 		};
+		A100000A2E50000000C0D001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B72LWYT2SZ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				PRODUCT_BUNDLE_IDENTIFIER = mx.masys.PangoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pango.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Pango";
+			};
+			name = Debug;
+		};
+		A100000B2E50000000C0D001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = B72LWYT2SZ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				PRODUCT_BUNDLE_IDENTIFIER = mx.masys.PangoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pango.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Pango";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -356,6 +463,15 @@
 			buildConfigurations = (
 				4346E5AA2E40714000CD1A93 /* Debug */,
 				4346E5AB2E40714000CD1A93 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000062E50000000C0D001 /* Build configuration list for PBXNativeTarget "PangoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000A2E50000000C0D001 /* Debug */,
+				A100000B2E50000000C0D001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pango.xcodeproj/xcshareddata/xcschemes/Pango.xcscheme
+++ b/Pango.xcodeproj/xcshareddata/xcschemes/Pango.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10000052E50000000C0D001"
+               BuildableName = "PangoTests.xctest"
+               BlueprintName = "PangoTests"
+               ReferencedContainer = "container:Pango.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Pango/Helpers/API/PangolinAPIClient.swift
+++ b/Pango/Helpers/API/PangolinAPIClient.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+struct PangolinAPIClient: Sendable {
+    private let configuration: PangolinAPIConfiguration
+    private let session: URLSession
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(
+        configuration: PangolinAPIConfiguration,
+        session: URLSession = .shared,
+        encoder: JSONEncoder = JSONEncoder(),
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.configuration = configuration
+        self.session = session
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    func send<Response: Decodable>(
+        _ method: PangolinHTTPMethod,
+        path: String,
+        queryItems: [URLQueryItem] = []
+    ) async throws -> PangolinResponse<Response> {
+        let data = try await perform(method, path: path, queryItems: queryItems, body: nil)
+        return try decode(PangolinResponse<Response>.self, from: data)
+    }
+
+    func send<Response: Decodable, Body: Encodable>(
+        _ method: PangolinHTTPMethod,
+        path: String,
+        queryItems: [URLQueryItem] = [],
+        body: Body
+    ) async throws -> PangolinResponse<Response> {
+        let encodedBody: Data
+        do {
+            encodedBody = try encoder.encode(body)
+        } catch {
+            throw PangolinAPIError.decoding
+        }
+        let data = try await perform(method, path: path, queryItems: queryItems, body: encodedBody)
+        return try decode(PangolinResponse<Response>.self, from: data)
+    }
+
+    func sendRaw<Response: Decodable>(
+        _ method: PangolinHTTPMethod,
+        path: String,
+        queryItems: [URLQueryItem] = []
+    ) async throws -> Response {
+        let data = try await perform(method, path: path, queryItems: queryItems, body: nil)
+        return try decode(Response.self, from: data)
+    }
+
+    private func perform(
+        _ method: PangolinHTTPMethod,
+        path: String,
+        queryItems: [URLQueryItem],
+        body: Data?
+    ) async throws -> Data {
+        let url = try requestURL(path: path, queryItems: queryItems)
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        request.setValue(configuration.authorizationHeader, forHTTPHeaderField: "Authorization")
+        if let body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw PangolinAPIError.transport
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PangolinAPIError.transport
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw mapError(statusCode: httpResponse.statusCode, data: data)
+        }
+
+        return data
+    }
+
+    private func decode<Response: Decodable>(_ type: Response.Type, from data: Data) throws -> Response {
+        do {
+            return try decoder.decode(type, from: data)
+        } catch {
+            throw PangolinAPIError.decoding
+        }
+    }
+
+    private func requestURL(path: String, queryItems: [URLQueryItem]) throws -> URL {
+        guard var components = URLComponents(url: configuration.baseURL, resolvingAgainstBaseURL: false) else {
+            throw PangolinAPIError.invalidBaseURL
+        }
+        let relativePath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        components.path = relativePath.isEmpty ? "/v1" : "/v1/\(relativePath)"
+        components.percentEncodedQuery = encodedQuery(queryItems)
+        guard let url = components.url else {
+            throw PangolinAPIError.invalidBaseURL
+        }
+        return url
+    }
+
+    private func encodedQuery(_ queryItems: [URLQueryItem]) -> String? {
+        guard !queryItems.isEmpty else {
+            return nil
+        }
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return queryItems.map { item in
+            let name = item.name.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
+            guard let value = item.value else {
+                return name
+            }
+            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
+            return "\(name)=\(encodedValue)"
+        }.joined(separator: "&")
+    }
+
+    private func mapError(statusCode: Int, data: Data) -> PangolinAPIError {
+        switch statusCode {
+        case 401:
+            return .unauthenticated
+        case 403:
+            return .forbidden
+        case 404, 405:
+            return .unsupported
+        case 400, 409, 422:
+            if let response = try? decoder.decode(PangolinResponse<PangolinEmptyResponse>.self, from: data) {
+                return .serverRejected(status: statusCode, message: response.message)
+            }
+            return .serverRejected(status: statusCode, message: "")
+        default:
+            return .httpFailure(status: statusCode)
+        }
+    }
+}

--- a/Pango/Helpers/API/PangolinAPIConfiguration.swift
+++ b/Pango/Helpers/API/PangolinAPIConfiguration.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct PangolinAPIConfiguration: Sendable {
+    enum Error: Swift.Error, Equatable {
+        case invalidBaseURL
+        case missingAPIKey
+    }
+
+    let baseURL: URL
+    private let apiKey: String
+
+    var authorizationHeader: String {
+        "Bearer \(apiKey)"
+    }
+
+    init(baseURLString: String, apiKey: String) throws {
+        let trimmedAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedAPIKey.isEmpty else {
+            throw Error.missingAPIKey
+        }
+
+        let trimmedURL = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmedURL),
+              components.scheme?.lowercased() == "https",
+              components.host?.isEmpty == false,
+              components.query == nil,
+              components.fragment == nil else {
+            throw Error.invalidBaseURL
+        }
+
+        var path = components.path
+        while path.count > 1 && path.hasSuffix("/") {
+            path.removeLast()
+        }
+        if path == "/" || path == "/v1" {
+            path = ""
+        }
+        components.path = path
+
+        guard let baseURL = components.url else {
+            throw Error.invalidBaseURL
+        }
+
+        self.baseURL = baseURL
+        self.apiKey = trimmedAPIKey
+    }
+}

--- a/Pango/Helpers/API/PangolinAPIError.swift
+++ b/Pango/Helpers/API/PangolinAPIError.swift
@@ -1,0 +1,35 @@
+enum PangolinAPIError: Error, Equatable, Sendable {
+    case invalidBaseURL
+    case missingAPIKey
+    case organizationRequired
+    case transport
+    case unauthenticated
+    case forbidden
+    case unsupported
+    case serverRejected(status: Int, message: String)
+    case httpFailure(status: Int)
+    case decoding
+
+    var localizationKey: String {
+        switch self {
+        case .invalidBaseURL:
+            return "ERROR_INVALID_SERVER_URL"
+        case .missingAPIKey, .unauthenticated:
+            return "ERROR_API_KEY"
+        case .organizationRequired:
+            return "ERROR_ORGANIZATION_REQUIRED"
+        case .transport:
+            return "ERROR_CONNECTING_TO_SERVER"
+        case .forbidden:
+            return "ERROR_API_PERMISSION"
+        case .unsupported:
+            return "ERROR_API_UNSUPPORTED"
+        case .serverRejected:
+            return "ERROR_API_REJECTED"
+        case .httpFailure:
+            return "ERROR_API_HTTP"
+        case .decoding:
+            return "ERROR_API_RESPONSE"
+        }
+    }
+}

--- a/Pango/Helpers/API/PangolinConnectionService.swift
+++ b/Pango/Helpers/API/PangolinConnectionService.swift
@@ -1,0 +1,40 @@
+struct PangolinConnectionService: Sendable {
+    private let client: PangolinAPIClient
+
+    init(client: PangolinAPIClient) {
+        self.client = client
+    }
+
+    func validate(organizationId: String?) async throws -> [Organization] {
+        let health: HealthCheckResponse = try await client.sendRaw(.get, path: "")
+        guard health.message == "Healthy" else {
+            throw PangolinAPIError.unsupported
+        }
+
+        let trimmedOrganizationId = organizationId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedOrganizationId.isEmpty {
+            let response: PangolinResponse<SitesResponse> = try await client.send(
+                .get,
+                path: "/org/\(trimmedOrganizationId)/sites"
+            )
+            guard response.success, !response.error else {
+                throw PangolinAPIError.serverRejected(status: response.status, message: response.message)
+            }
+            return [Organization(orgId: trimmedOrganizationId, name: trimmedOrganizationId)]
+        }
+
+        let response: PangolinResponse<OrganizationsResponse>
+        do {
+            response = try await client.send(.get, path: "/orgs")
+        } catch PangolinAPIError.forbidden {
+            throw PangolinAPIError.organizationRequired
+        }
+        guard response.success, !response.error else {
+            throw PangolinAPIError.serverRejected(status: response.status, message: response.message)
+        }
+        guard let organizations = response.data?.orgs else {
+            throw PangolinAPIError.decoding
+        }
+        return organizations
+    }
+}

--- a/Pango/Helpers/API/PangolinHTTPMethod.swift
+++ b/Pango/Helpers/API/PangolinHTTPMethod.swift
@@ -1,0 +1,7 @@
+enum PangolinHTTPMethod: String, Sendable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
+}

--- a/Pango/Helpers/API/PangolinResponse.swift
+++ b/Pango/Helpers/API/PangolinResponse.swift
@@ -1,0 +1,10 @@
+struct PangolinResponse<Value: Decodable>: Decodable {
+    let data: Value?
+    let success: Bool
+    let error: Bool
+    let message: String
+    let status: Int
+}
+
+struct PangolinEmptyResponse: Decodable, Equatable {
+}

--- a/Pango/Localizable.xcstrings
+++ b/Pango/Localizable.xcstrings
@@ -629,6 +629,86 @@
         }
       }
     },
+    "ERROR_API_HTTP" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Pangolin server returned an unexpected error."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El servidor Pangolin devolvió un error inesperado."
+          }
+        }
+      }
+    },
+    "ERROR_API_PERMISSION" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The API key does not have permission for this organization."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La clave API no tiene permiso para esta organización."
+          }
+        }
+      }
+    },
+    "ERROR_API_REJECTED" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pangolin rejected the request."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pangolin rechazó la solicitud."
+          }
+        }
+      }
+    },
+    "ERROR_API_RESPONSE" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Pangolin server returned an invalid response."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El servidor Pangolin devolvió una respuesta no válida."
+          }
+        }
+      }
+    },
+    "ERROR_API_UNSUPPORTED" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This server does not support the required Pangolin API."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este servidor no admite la API de Pangolin requerida."
+          }
+        }
+      }
+    },
     "ERROR_CONNECTING_TO_SERVER" : {
       "localizations" : {
         "en" : {
@@ -641,6 +721,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No se puede conectar al servidor, ¡verifica la URL del Servidor!"
+          }
+        }
+      }
+    },
+    "ERROR_INVALID_SERVER_URL" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter a valid HTTPS Pangolin API URL."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresa una URL HTTPS válida para la API de Pangolin."
+          }
+        }
+      }
+    },
+    "ERROR_ORGANIZATION_REQUIRED" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter the organization ID for this organization API key."
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingresa el ID de la organización para esta clave API de organización."
           }
         }
       }

--- a/Pango/Views/InstanceView.swift
+++ b/Pango/Views/InstanceView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Alamofire
 
 struct InstanceView: View {
     
@@ -20,8 +19,7 @@ struct InstanceView: View {
     @State private var serverUrl = ""
     @State private var apiKey = ""
     @State private var organizationId = ""
-    @State private var connectionError: Bool = false
-    @State private var authError: Bool = false
+    @State private var errorKey: String?
     @State private var isLoading: Bool = false
         
     var body: some View {
@@ -46,13 +44,8 @@ struct InstanceView: View {
                         .multilineTextAlignment(.trailing)
                 }
                 
-                if connectionError == true {
-                    Text("ERROR_CONNECTING_TO_SERVER")
-                        .foregroundStyle(.red)
-                        .font(.system(size: 14))
-                }
-                if authError == true {
-                    Text("ERROR_API_KEY")
+                if let errorKey {
+                    Text(LocalizedStringKey(errorKey))
                         .foregroundStyle(.red)
                         .font(.system(size: 14))
                 }
@@ -87,51 +80,57 @@ struct InstanceView: View {
     }
     
     private func save() {
-        if self.serverUrl.isEmpty || self.apiKey.isEmpty {
-            print("empty")
-            return
-        }
-        self.serverUrl = baseDomain(from: self.serverUrl)
-        
-        self.connectionError = false
-        self.authError = false
-        self.isLoading = true
-        
-        self.pangolinServerUrl = self.serverUrl
-        self.pangolinApiKey = self.apiKey
-        self.pangolinOrganizationId = self.organizationId
+        errorKey = nil
+        do {
+            let configuration = try PangolinAPIConfiguration(
+                baseURLString: serverUrl,
+                apiKey: apiKey
+            )
+            isLoading = true
+            Task {
+                do {
+                    let service = PangolinConnectionService(
+                        client: PangolinAPIClient(configuration: configuration)
+                    )
+                    let organizations = try await service.validate(organizationId: organizationId)
+                    guard let selectedOrganization = selectedOrganization(from: organizations) else {
+                        throw PangolinAPIError.forbidden
+                    }
 
-        Request.healthCheck { healthSuccess in
-            if healthSuccess {
-                self.authenticate()
-            } else {
-                self.isLoading = false
-                self.connectionError = true
+                    serverUrl = configuration.baseURL.absoluteString
+                    organizationId = selectedOrganization.orgId
+                    pangolinServerUrl = serverUrl
+                    pangolinApiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                    pangolinOrganizationId = organizationId
+                    appService.organizations = organizations
+                    isLoading = false
+                    dismiss()
+                } catch let error as PangolinAPIError {
+                    isLoading = false
+                    errorKey = error.localizationKey
+                } catch {
+                    isLoading = false
+                    errorKey = PangolinAPIError.transport.localizationKey
+                }
             }
+        } catch let error as PangolinAPIConfiguration.Error {
+            switch error {
+            case .invalidBaseURL:
+                errorKey = PangolinAPIError.invalidBaseURL.localizationKey
+            case .missingAPIKey:
+                errorKey = PangolinAPIError.missingAPIKey.localizationKey
+            }
+        } catch {
+            errorKey = PangolinAPIError.invalidBaseURL.localizationKey
         }
     }
-    
-    private func authenticate() {
-        if self.pangolinOrganizationId.isEmpty {
-            self.appService.fetchOrgs { success, orgs in
-                self.isLoading = false
-                if success {
-                    self.dismiss()
-                } else {
-                    self.authError = true
-                }
-            }
-        } else {
-            self.appService.fetchOrgs { _, _ in }
-            self.appService.fetchSites { success, sites in
-                self.isLoading = false
-                if success {
-                    self.dismiss()
-                } else {
-                    self.authError = true
-                }
-            }
+
+    private func selectedOrganization(from organizations: [Organization]) -> Organization? {
+        let requestedOrganizationId = organizationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        if requestedOrganizationId.isEmpty {
+            return organizations.first
         }
+        return organizations.first { $0.orgId == requestedOrganizationId }
     }
 }
 

--- a/Pango/Views/SettingsView.swift
+++ b/Pango/Views/SettingsView.swift
@@ -110,7 +110,7 @@ struct SettingsView: View {
                     HStack {
                         Text("API Compatibility")
                         Spacer()
-                        Text("Pangolin API **v1.18.4**")
+                        Text("Pangolin API **v1.22.x**")
                             .font(.callout)
                             .foregroundColor(.secondary)
                     }

--- a/PangoTests/API/PangolinAPIClientTests.swift
+++ b/PangoTests/API/PangolinAPIClientTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+@testable import Pango
+
+@Suite("Pangolin API client", .serialized)
+struct PangolinAPIClientTests {
+    private struct Payload: Codable, Equatable {
+        let value: String
+    }
+
+    private func makeClient() throws -> PangolinAPIClient {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [URLProtocolStub.self]
+        return PangolinAPIClient(
+            configuration: try PangolinAPIConfiguration(
+                baseURLString: "https://api.example.com/v1/",
+                apiKey: "synthetic-key"
+            ),
+            session: URLSession(configuration: sessionConfiguration)
+        )
+    }
+
+    @Test("constructs an authenticated request with encoded query items")
+    func constructsRequest() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.absoluteString == "https://api.example.com/v1/orgs?email=person%2Btest%40example.com")
+            #expect(request.httpMethod == "GET")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer synthetic-key")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == nil)
+            return .init(
+                statusCode: 200,
+                data: Data(#"{"data":{"value":"ok"},"success":true,"error":false,"message":"","status":200}"#.utf8)
+            )
+        }
+
+        let response: PangolinResponse<Payload> = try await makeClient().send(
+            .get,
+            path: "/orgs",
+            queryItems: [URLQueryItem(name: "email", value: "person+test@example.com")]
+        )
+
+        #expect(response.data == Payload(value: "ok"))
+    }
+
+    @Test("encodes a JSON body")
+    func encodesJSONBody() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.httpMethod == "PATCH")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+            let body = try #require(request.bodyData)
+            #expect(try JSONDecoder().decode(Payload.self, from: body) == Payload(value: "changed"))
+            return .init(
+                statusCode: 200,
+                data: Data(#"{"success":true,"error":false,"message":"Saved","status":200}"#.utf8)
+            )
+        }
+
+        let response: PangolinResponse<PangolinEmptyResponse> = try await makeClient().send(
+            .patch,
+            path: "/resource/1",
+            body: Payload(value: "changed")
+        )
+
+        #expect(response.success)
+    }
+
+    @Test(
+        "maps authentication and capability statuses",
+        arguments: [
+            (401, PangolinAPIError.unauthenticated),
+            (403, PangolinAPIError.forbidden),
+            (404, PangolinAPIError.unsupported),
+            (405, PangolinAPIError.unsupported),
+            (500, PangolinAPIError.httpFailure(status: 500))
+        ]
+    )
+    func mapsHTTPStatus(statusCode: Int, expectedError: PangolinAPIError) async throws {
+        URLProtocolStub.handler = { _ in
+            .init(statusCode: statusCode, data: Data())
+        }
+
+        await #expect(throws: expectedError) {
+            let _: PangolinResponse<PangolinEmptyResponse> = try await makeClient().send(.get, path: "/orgs")
+        }
+    }
+
+    @Test("preserves a Pangolin validation rejection")
+    func preservesValidationRejection() async throws {
+        URLProtocolStub.handler = { _ in
+            .init(
+                statusCode: 422,
+                data: Data(#"{"success":false,"error":true,"message":"Synthetic rejection","status":422}"#.utf8)
+            )
+        }
+
+        await #expect(throws: PangolinAPIError.serverRejected(status: 422, message: "Synthetic rejection")) {
+            let _: PangolinResponse<PangolinEmptyResponse> = try await makeClient().send(.post, path: "/resource/1")
+        }
+    }
+
+    @Test("maps malformed JSON without exposing the key")
+    func mapsMalformedJSON() async throws {
+        URLProtocolStub.handler = { _ in
+            .init(statusCode: 200, data: Data("not-json".utf8))
+        }
+
+        do {
+            let _: PangolinResponse<PangolinEmptyResponse> = try await makeClient().send(.get, path: "/orgs")
+            Issue.record("Expected decoding to fail")
+        } catch let error as PangolinAPIError {
+            #expect(error == .decoding)
+            #expect(!String(describing: error).contains("synthetic-key"))
+        }
+    }
+
+    @Test("maps transport failures")
+    func mapsTransportFailure() async throws {
+        URLProtocolStub.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        await #expect(throws: PangolinAPIError.transport) {
+            let _: PangolinResponse<PangolinEmptyResponse> = try await makeClient().send(.get, path: "/orgs")
+        }
+    }
+}
+
+private extension URLRequest {
+    var bodyData: Data? {
+        if let httpBody {
+            return httpBody
+        }
+        guard let httpBodyStream else {
+            return nil
+        }
+        httpBodyStream.open()
+        defer { httpBodyStream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1_024)
+        defer { buffer.deallocate() }
+        while httpBodyStream.hasBytesAvailable {
+            let count = httpBodyStream.read(buffer, maxLength: 1_024)
+            guard count > 0 else {
+                break
+            }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/PangoTests/API/PangolinAPIConfigurationTests.swift
+++ b/PangoTests/API/PangolinAPIConfigurationTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import Pango
+
+@Suite("Pangolin API configuration")
+struct PangolinAPIConfigurationTests {
+    @Test("normalizes a base URL")
+    func normalizesBaseURL() throws {
+        let configuration = try PangolinAPIConfiguration(
+            baseURLString: "https://api.pangolin.net/",
+            apiKey: "test-id.test-secret"
+        )
+
+        #expect(configuration.baseURL.absoluteString == "https://api.pangolin.net")
+    }
+
+    @Test("rejects a non-HTTPS URL")
+    func rejectsNonHTTPSURL() {
+        #expect(throws: PangolinAPIConfiguration.Error.invalidBaseURL) {
+            try PangolinAPIConfiguration(
+                baseURLString: "http://api.example.com",
+                apiKey: "key"
+            )
+        }
+    }
+
+    @Test("rejects an empty API key")
+    func rejectsEmptyKey() {
+        #expect(throws: PangolinAPIConfiguration.Error.missingAPIKey) {
+            try PangolinAPIConfiguration(
+                baseURLString: "https://api.example.com",
+                apiKey: "  "
+            )
+        }
+    }
+
+    @Test("removes a trailing API version path")
+    func removesVersionPath() throws {
+        let configuration = try PangolinAPIConfiguration(
+            baseURLString: "https://api.example.com/v1/",
+            apiKey: "key"
+        )
+
+        #expect(configuration.baseURL.absoluteString == "https://api.example.com")
+    }
+}

--- a/PangoTests/API/PangolinConnectionServiceTests.swift
+++ b/PangoTests/API/PangolinConnectionServiceTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import Pango
+
+@Suite("Pangolin connection validation", .serialized)
+struct PangolinConnectionServiceTests {
+    private func makeService() throws -> PangolinConnectionService {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [URLProtocolStub.self]
+        let configuration = try PangolinAPIConfiguration(
+            baseURLString: "https://api.example.com",
+            apiKey: "synthetic-key"
+        )
+        return PangolinConnectionService(
+            client: PangolinAPIClient(
+                configuration: configuration,
+                session: URLSession(configuration: sessionConfiguration)
+            )
+        )
+    }
+
+    @Test("validates health before loading organizations")
+    func validatesHealthAndOrganizations() async throws {
+        URLProtocolStub.handler = { request in
+            switch request.url?.path {
+            case "/v1":
+                return .init(statusCode: 200, data: Data(#"{"message":"Healthy"}"#.utf8))
+            case "/v1/orgs":
+                return .init(
+                    statusCode: 200,
+                    data: Data(#"{"data":{"orgs":[{"orgId":"synthetic-org","name":"Synthetic"}]},"success":true,"error":false,"message":"","status":200}"#.utf8)
+                )
+            default:
+                return .init(statusCode: 404, data: Data())
+            }
+        }
+
+        let organizations = try await makeService().validate(organizationId: nil)
+
+        #expect(organizations.count == 1)
+        #expect(organizations.first?.orgId == "synthetic-org")
+    }
+
+    @Test("rejects an unhealthy API")
+    func rejectsUnhealthyAPI() async throws {
+        URLProtocolStub.handler = { _ in
+            .init(statusCode: 200, data: Data(#"{"message":"Starting"}"#.utf8))
+        }
+
+        await #expect(throws: PangolinAPIError.unsupported) {
+            try await makeService().validate(organizationId: nil)
+        }
+    }
+
+    @Test("preserves authentication failures")
+    func preservesAuthenticationFailure() async throws {
+        URLProtocolStub.handler = { request in
+            if request.url?.path == "/v1" {
+                return .init(statusCode: 200, data: Data(#"{"message":"Healthy"}"#.utf8))
+            }
+            return .init(statusCode: 401, data: Data())
+        }
+
+        await #expect(throws: PangolinAPIError.unauthenticated) {
+            try await makeService().validate(organizationId: nil)
+        }
+    }
+
+    @Test("asks for an organization when discovery is forbidden")
+    func requiresOrganizationForScopedKey() async throws {
+        URLProtocolStub.handler = { request in
+            if request.url?.path == "/v1" {
+                return .init(statusCode: 200, data: Data(#"{"message":"Healthy"}"#.utf8))
+            }
+            return .init(statusCode: 403, data: Data())
+        }
+
+        await #expect(throws: PangolinAPIError.organizationRequired) {
+            try await makeService().validate(organizationId: nil)
+        }
+    }
+
+    @Test("validates an organization-scoped key through its organization")
+    func validatesOrganizationScopedKey() async throws {
+        URLProtocolStub.handler = { request in
+            switch request.url?.path {
+            case "/v1":
+                return .init(statusCode: 200, data: Data(#"{"message":"Healthy"}"#.utf8))
+            case "/v1/org/synthetic-org/sites":
+                return .init(
+                    statusCode: 200,
+                    data: Data(#"{"data":{"sites":[]},"success":true,"error":false,"message":"","status":200}"#.utf8)
+                )
+            default:
+                return .init(statusCode: 403, data: Data())
+            }
+        }
+
+        let organizations = try await makeService().validate(organizationId: "synthetic-org")
+
+        #expect(organizations.first?.orgId == "synthetic-org")
+    }
+}

--- a/PangoTests/API/PangolinResponseTests.swift
+++ b/PangoTests/API/PangolinResponseTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import Pango
+
+@Suite("Pangolin response envelope")
+struct PangolinResponseTests {
+    private struct Payload: Decodable, Equatable {
+        let value: String
+    }
+
+    @Test("decodes successful data")
+    func decodesSuccessfulData() throws {
+        let data = Data(#"{"data":{"value":"synthetic"},"success":true,"error":false,"message":"","status":200}"#.utf8)
+
+        let response = try JSONDecoder().decode(PangolinResponse<Payload>.self, from: data)
+
+        #expect(response.data == Payload(value: "synthetic"))
+        #expect(response.success)
+        #expect(!response.error)
+        #expect(response.status == 200)
+    }
+
+    @Test("decodes a successful response without data")
+    func decodesSuccessfulResponseWithoutData() throws {
+        let data = Data(#"{"success":true,"error":false,"message":"Saved","status":200}"#.utf8)
+
+        let response = try JSONDecoder().decode(PangolinResponse<PangolinEmptyResponse>.self, from: data)
+
+        #expect(response.data == nil)
+        #expect(response.message == "Saved")
+    }
+
+    @Test("preserves a server rejection")
+    func preservesServerRejection() throws {
+        let data = Data(#"{"success":false,"error":true,"message":"Synthetic rejection","status":422}"#.utf8)
+
+        let response = try JSONDecoder().decode(PangolinResponse<PangolinEmptyResponse>.self, from: data)
+
+        #expect(response.error)
+        #expect(response.message == "Synthetic rejection")
+        #expect(response.status == 422)
+    }
+}

--- a/PangoTests/Support/URLProtocolStub.swift
+++ b/PangoTests/Support/URLProtocolStub.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+final class URLProtocolStub: URLProtocol, @unchecked Sendable {
+    struct Response {
+        let statusCode: Int
+        let data: Data
+    }
+
+    static var handler: (@Sendable (URLRequest) throws -> Response)?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let result = try handler(request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: result.statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: result.data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a typed Pangolin API client with safe URL/query encoding and error mapping
- validate instance settings before persisting them
- support root-key organization discovery and organization-scoped Cloud keys
- add the project unit-test target and API regression coverage

## Verification
- `xcodebuild -quiet -scheme Pango -project Pango.xcodeproj -derivedDataPath /private/tmp/pango-api-foundation-tests -destination "platform=iOS Simulator,name=iPhone 17 Pro Max" test`
- `xcodebuild -quiet -scheme Pango -project Pango.xcodeproj -derivedDataPath /private/tmp/pango-api-foundation-final -destination "generic/platform=iOS Simulator" clean build`
- Pangolin Cloud read-only smoke test: `/v1` returned 200 Healthy; `/v1/orgs` returned the expected 403 for an organization-scoped key

## Manual test
1. Enter `https://api.pangolin.net`, the organization API key, and its organization ID.
2. Save and confirm the instance is accepted.
3. Enter an invalid key and confirm the saved working configuration is preserved.
4. Clear the organization ID with an organization-scoped key and confirm Pango asks for it.