### PR TITLE
Add Pangolin site management

### DIFF
--- a/Pango/Helpers/API/PangolinSiteService.swift
+++ b/Pango/Helpers/API/PangolinSiteService.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+struct SitesPage: Decodable, Equatable {
+    let sites: [Site]
+    let pagination: Pagination
+}
+
+struct SiteCredentials: Equatable {
+    let id: String
+    let secret: String
+}
+
+struct CreatedSite: Equatable {
+    let site: Site
+    let credentials: SiteCredentials
+}
+
+struct PangolinSiteService: Sendable {
+    private struct CreateSiteBody: Encodable {
+        let name: String
+        let type = "newt"
+    }
+
+    private struct RenameSiteBody: Encodable {
+        let name: String
+    }
+
+    private let client: PangolinAPIClient
+    private let organizationId: String
+
+    init(client: PangolinAPIClient, organizationId: String) {
+        self.client = client
+        self.organizationId = organizationId
+    }
+
+    func listSites(page: Int = 1, pageSize: Int = 100) async throws -> SitesPage {
+        let response: PangolinResponse<SitesPage> = try await client.send(
+            .get,
+            path: "/org/\(organizationId)/sites",
+            queryItems: [
+                URLQueryItem(name: "pageSize", value: String(pageSize)),
+                URLQueryItem(name: "page", value: String(page))
+            ]
+        )
+        return try response.requireData()
+    }
+
+    func createNewtSite(name: String) async throws -> CreatedSite {
+        let response: PangolinResponse<Site> = try await client.send(
+            .put,
+            path: "/org/\(organizationId)/site",
+            body: CreateSiteBody(name: name)
+        )
+        let site = try response.requireData()
+        guard let id = site.newtId, let secret = site.secret else {
+            throw PangolinAPIError.decoding
+        }
+        return CreatedSite(site: site, credentials: SiteCredentials(id: id, secret: secret))
+    }
+
+    func getSite(siteId: Int) async throws -> Site {
+        let response: PangolinResponse<Site> = try await client.send(
+            .get,
+            path: "/site/\(siteId)"
+        )
+        return try response.requireData()
+    }
+
+    func renameSite(siteId: Int, name: String) async throws -> Site {
+        let response: PangolinResponse<Site> = try await client.send(
+            .post,
+            path: "/site/\(siteId)",
+            body: RenameSiteBody(name: name)
+        )
+        return try response.requireData()
+    }
+
+    func deleteSite(siteId: Int) async throws {
+        let response: PangolinResponse<PangolinEmptyResponse> = try await client.send(
+            .delete,
+            path: "/site/\(siteId)",
+            queryItems: [URLQueryItem(name: "deleteResources", value: "false")]
+        )
+        guard response.success, !response.error else {
+            throw PangolinAPIError.serverRejected(status: response.status, message: response.message)
+        }
+    }
+}
+
+private extension PangolinResponse {
+    func requireData() throws -> Value {
+        guard success, !error else {
+            throw PangolinAPIError.serverRejected(status: status, message: message)
+        }
+        guard let data else {
+            throw PangolinAPIError.decoding
+        }
+        return data
+    }
+}

--- a/Pango/Helpers/AppService.swift
+++ b/Pango/Helpers/AppService.swift
@@ -33,10 +33,66 @@ class AppService: ObservableObject {
     }
     
     public func fetchSites(completionHandler: @escaping (_ success: Bool, _ sites: [Site]) -> Void) {
-        SitesRequest.fetch { success, sites in
-            self.sites = sites
-            completionHandler(success, sites)
+        Task {
+            do {
+                let sites = try await fetchSites()
+                completionHandler(true, sites)
+            } catch {
+                completionHandler(false, [])
+            }
         }
+    }
+
+    public func fetchSites() async throws -> [Site] {
+        let page = try await siteService().listSites()
+        sites = page.sites
+        return page.sites
+    }
+
+    public func createNewtSite(name: String) async throws -> CreatedSite {
+        let created = try await siteService().createNewtSite(name: name)
+        var site = created.site
+        site.secret = nil
+        sites.append(site)
+        return created
+    }
+
+    public func getSite(siteId: Int) async throws -> Site {
+        try await siteService().getSite(siteId: siteId)
+    }
+
+    public func renameSite(siteId: Int, name: String) async throws -> Site {
+        let site = try await siteService().renameSite(siteId: siteId, name: name)
+        if let index = sites.firstIndex(where: { $0.siteId == siteId }) {
+            sites[index] = site
+        }
+        return site
+    }
+
+    public func deleteSite(siteId: Int) async throws {
+        try await siteService().deleteSite(siteId: siteId)
+        sites.removeAll { $0.siteId == siteId }
+    }
+
+    private func siteService() throws -> PangolinSiteService {
+        let configuration: PangolinAPIConfiguration
+        do {
+            configuration = try PangolinAPIConfiguration(
+                baseURLString: pangolinServerUrl,
+                apiKey: pangolinApiKey
+            )
+        } catch PangolinAPIConfiguration.Error.invalidBaseURL {
+            throw PangolinAPIError.invalidBaseURL
+        } catch PangolinAPIConfiguration.Error.missingAPIKey {
+            throw PangolinAPIError.missingAPIKey
+        }
+        guard !pangolinOrganizationId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PangolinAPIError.organizationRequired
+        }
+        return PangolinSiteService(
+            client: PangolinAPIClient(configuration: configuration),
+            organizationId: pangolinOrganizationId
+        )
     }
     
     public func fetchResources() {

--- a/Pango/Helpers/Models.swift
+++ b/Pango/Helpers/Models.swift
@@ -32,7 +32,7 @@ struct ResourcesResponse: Decodable {
     var pagination: Pagination?
 }
 
-struct Pagination: Decodable {
+struct Pagination: Decodable, Equatable {
     var total: Int
     var pageSize: Int
     var page: Int

--- a/Pango/Localizable.xcstrings
+++ b/Pango/Localizable.xcstrings
@@ -70,6 +70,90 @@
     "abc123" : {
 
     },
+    "COPY" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Copiar" } }
+      }
+    },
+    "CREATE" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Create" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Crear" } }
+      }
+    },
+    "CREATE_SITE" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Create Site" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Crear Sitio" } }
+      }
+    },
+    "CREDENTIALS_ONE_TIME_WARNING" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy these credentials now. The secret is shown only once." } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Copia estas credenciales ahora. El secreto se muestra solo una vez." } }
+      }
+    },
+    "DELETE_SITE" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete Site" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Eliminar Sitio" } }
+      }
+    },
+    "DELETE_SITE_CONFIRMATION" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Are you sure you want to delete this site?" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "¿Estás seguro de que deseas eliminar este sitio?" } }
+      }
+    },
+    "DELETE_SITE_RESOURCE_WARNING" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Associated resources will not be deleted." } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Los recursos asociados no se eliminarán." } }
+      }
+    },
+    "DONE" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Done" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Listo" } }
+      }
+    },
+    "ERROR" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Error" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Error" } }
+      }
+    },
+    "NEWT_ID" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Newt ID" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "ID de Newt" } }
+      }
+    },
+    "SECRET" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Secret" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Secreto" } }
+      }
+    },
+    "SITE_CREATED" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site Created" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Sitio Creado" } }
+      }
+    },
+    "SITE_CREDENTIALS" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site Credentials" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Credenciales del Sitio" } }
+      }
+    },
+    "SITE_ID" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site ID" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "ID del Sitio" } }
+      }
+    },
     "ACCESS_CONTROL" : {
       "localizations" : {
         "en" : {

--- a/Pango/Models/Site.swift
+++ b/Pango/Models/Site.swift
@@ -5,7 +5,7 @@
 //  Created by Yaser Almasri on 24/08/25.
 //
 
-struct Site: Decodable {
+struct Site: Codable, Equatable {
     var siteId: Int
     var niceId: String?
     var name: String
@@ -21,6 +21,14 @@ struct Site: Decodable {
     var newtUpdateAvailable: Bool?
     var uptimePercent: Float?
     var pending: Bool?
+    var exitNodeId: Int?
+    var exitNodeName: String?
+    var exitNodeEndpoint: String?
+    var remoteExitNodeId: Int?
+    var resourceCount: Int?
+    var status: String?
+    var newtId: String?
+    var secret: String?
 }
 
 extension Site {
@@ -39,7 +47,16 @@ extension Site {
             address: "",
             newtVersion: "1.4.0",
             newtUpdateAvailable: false,
-            uptimePercent: nil
+            uptimePercent: nil,
+            pending: false,
+            exitNodeId: nil,
+            exitNodeName: nil,
+            exitNodeEndpoint: nil,
+            remoteExitNodeId: nil,
+            resourceCount: 0,
+            status: "approved",
+            newtId: nil,
+            secret: nil
         )
     }
 }

--- a/Pango/Models/Site.swift
+++ b/Pango/Models/Site.swift
@@ -5,7 +5,7 @@
 //  Created by Yaser Almasri on 24/08/25.
 //
 
-struct Site: Codable, Equatable {
+struct Site: Decodable, Equatable {
     var siteId: Int
     var niceId: String?
     var name: String

--- a/Pango/Views/SiteCreateView.swift
+++ b/Pango/Views/SiteCreateView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 struct SiteCreateView: View {
     @Environment(\.dismiss) private var dismiss
@@ -55,7 +56,15 @@ struct SiteCreateView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title).font(.caption).foregroundStyle(.secondary)
             Text(value).font(.system(.body, design: .monospaced)).textSelection(.enabled)
-            Button("COPY") { UIPasteboard.general.string = value }
+            Button("COPY") {
+                UIPasteboard.general.setItems(
+                    [[UTType.plainText.identifier: value]],
+                    options: [
+                        .localOnly: true,
+                        .expirationDate: Date().addingTimeInterval(300)
+                    ]
+                )
+            }
         }
     }
 

--- a/Pango/Views/SiteCreateView.swift
+++ b/Pango/Views/SiteCreateView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import UIKit
+
+struct SiteCreateView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appService: AppService
+    @State private var name = ""
+    @State private var isSaving = false
+    @State private var credentials: SiteCredentials?
+    @State private var errorKey: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if let credentials {
+                    Section("SITE_CREDENTIALS") {
+                        credentialRow(title: "NEWT_ID", value: credentials.id)
+                        credentialRow(title: "SECRET", value: credentials.secret)
+                    }
+                    Section {
+                        Text("CREDENTIALS_ONE_TIME_WARNING")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Section("SITE") {
+                        TextField("NAME", text: $name)
+                        LabeledContent("TYPE", value: "Newt")
+                    }
+                }
+            }
+            .navigationTitle(credentials == nil ? "CREATE_SITE" : "SITE_CREATED")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(credentials == nil ? "CANCEL" : "DONE") { dismiss() }
+                }
+                if credentials == nil {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("CREATE") { create() }
+                            .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
+                    }
+                }
+            }
+            .alert("ERROR", isPresented: Binding(
+                get: { errorKey != nil },
+                set: { if !$0 { errorKey = nil } }
+            )) {
+                Button("OK", role: .cancel) { errorKey = nil }
+            } message: {
+                if let errorKey { Text(LocalizedStringKey(errorKey)) }
+            }
+        }
+    }
+
+    private func credentialRow(title: LocalizedStringKey, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            Text(value).font(.system(.body, design: .monospaced)).textSelection(.enabled)
+            Button("COPY") { UIPasteboard.general.string = value }
+        }
+    }
+
+    private func create() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        isSaving = true
+        Task {
+            defer { isSaving = false }
+            do {
+                credentials = try await appService.createNewtSite(name: trimmedName).credentials
+            } catch let error as PangolinAPIError {
+                errorKey = error.localizationKey
+            } catch {
+                errorKey = "ERROR_CONNECTING_TO_SERVER"
+            }
+        }
+    }
+}

--- a/Pango/Views/SiteDetailView.swift
+++ b/Pango/Views/SiteDetailView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+struct SiteDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appService: AppService
+    @State private var site: Site
+    @State private var name: String
+    @State private var isSaving = false
+    @State private var confirmsDeletion = false
+    @State private var errorKey: String?
+
+    init(site: Site) {
+        self._site = State(initialValue: site)
+        self._name = State(initialValue: site.name)
+    }
+
+    var body: some View {
+        Form {
+            Section("SITE") {
+                TextField("NAME", text: $name)
+                LabeledContent("TYPE", value: site.type.capitalized)
+                LabeledContent("STATUS", value: site.status?.capitalized ?? (site.online == true ? "Online" : "Offline"))
+                if let niceId = site.niceId {
+                    LabeledContent("SITE_ID", value: niceId)
+                }
+                if let resourceCount = site.resourceCount {
+                    LabeledContent("RESOURCES", value: String(resourceCount))
+                }
+            }
+            Section {
+                Button("SAVE") { rename() }
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || name == site.name || isSaving)
+            }
+            Section {
+                Button("DELETE_SITE", role: .destructive) { confirmsDeletion = true }
+                    .disabled(isSaving)
+            } footer: {
+                Text("DELETE_SITE_RESOURCE_WARNING")
+            }
+        }
+        .navigationTitle(site.name)
+        .task { await refresh() }
+        .confirmationDialog("DELETE_SITE_CONFIRMATION", isPresented: $confirmsDeletion, titleVisibility: .visible) {
+            Button("DELETE", role: .destructive) { delete() }
+            Button("CANCEL", role: .cancel) {}
+        }
+        .alert("ERROR", isPresented: Binding(
+            get: { errorKey != nil },
+            set: { if !$0 { errorKey = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorKey = nil }
+        } message: {
+            if let errorKey { Text(LocalizedStringKey(errorKey)) }
+        }
+    }
+
+    private func refresh() async {
+        do {
+            site = try await appService.getSite(siteId: site.siteId)
+            name = site.name
+        } catch let error as PangolinAPIError {
+            errorKey = error.localizationKey
+        } catch {
+            errorKey = "ERROR_CONNECTING_TO_SERVER"
+        }
+    }
+
+    private func rename() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        isSaving = true
+        Task {
+            defer { isSaving = false }
+            do {
+                site = try await appService.renameSite(siteId: site.siteId, name: trimmedName)
+                name = site.name
+            } catch let error as PangolinAPIError {
+                errorKey = error.localizationKey
+            } catch {
+                errorKey = "ERROR_CONNECTING_TO_SERVER"
+            }
+        }
+    }
+
+    private func delete() {
+        isSaving = true
+        Task {
+            defer { isSaving = false }
+            do {
+                try await appService.deleteSite(siteId: site.siteId)
+                dismiss()
+            } catch let error as PangolinAPIError {
+                errorKey = error.localizationKey
+            } catch {
+                errorKey = "ERROR_CONNECTING_TO_SERVER"
+            }
+        }
+    }
+}

--- a/Pango/Views/SitesView.swift
+++ b/Pango/Views/SitesView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Alamofire
 
 enum SiteSegment {
     case all
@@ -17,9 +16,11 @@ struct SitesView: View {
 
     @EnvironmentObject var appService: AppService
     @State private var selectedSegment: SiteSegment = .all
+    @State private var isCreatingSite = false
+    @State private var errorKey: String?
 
-    var pendingSites: [Site] { appService.sites.filter { $0.pending == true } }
-    var activeSites: [Site] { appService.sites.filter { $0.pending != true } }
+    var pendingSites: [Site] { appService.sites.filter { $0.status == "pending" || $0.pending == true } }
+    var activeSites: [Site] { appService.sites.filter { $0.status != "pending" && $0.pending != true } }
 
     var body: some View {
         NavigationStack {
@@ -39,14 +40,40 @@ struct SitesView: View {
                 }
             }
             .navigationTitle(Text("SITES"))
-            .onAppear {
-                self.fetch()
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        isCreatingSite = true
+                    } label: {
+                        Label("CREATE_SITE", systemImage: "plus")
+                    }
+                }
             }
+            .sheet(isPresented: $isCreatingSite) {
+                SiteCreateView()
+                    .environmentObject(appService)
+            }
+            .alert("ERROR", isPresented: Binding(
+                get: { errorKey != nil },
+                set: { if !$0 { errorKey = nil } }
+            )) {
+                Button("OK", role: .cancel) { errorKey = nil }
+            } message: {
+                if let errorKey { Text(LocalizedStringKey(errorKey)) }
+            }
+            .task { await fetch() }
+            .refreshable { await fetch() }
         }
     }
 
-    private func fetch() {
-        self.appService.fetchSites { _, _ in }
+    private func fetch() async {
+        do {
+            _ = try await appService.fetchSites()
+        } catch let error as PangolinAPIError {
+            errorKey = error.localizationKey
+        } catch {
+            errorKey = "ERROR_CONNECTING_TO_SERVER"
+        }
     }
 }
 
@@ -55,7 +82,13 @@ extension SitesView {
         ScrollView {
             LazyVStack(spacing: 8) {
                 ForEach(activeSites, id: \.siteId) { site in
-                    siteCard(site)
+                    NavigationLink {
+                        SiteDetailView(site: site)
+                            .environmentObject(appService)
+                    } label: {
+                        siteCard(site)
+                    }
+                    .buttonStyle(.plain)
                 }//loop
             }//lazystack
             .padding(.vertical, 8)
@@ -128,13 +161,13 @@ extension SitesView {
 
     private func approve(_ site: Site) {
         SitesRequest.approve(siteId: site.siteId) { success in
-            if success { self.fetch() }
+            if success { Task { await self.fetch() } }
         }
     }
 
     private func reject(_ site: Site) {
         SitesRequest.reject(siteId: site.siteId) { success in
-            if success { self.fetch() }
+            if success { Task { await self.fetch() } }
         }
     }
 }

--- a/PangoTests/API/PangolinSiteServiceTests.swift
+++ b/PangoTests/API/PangolinSiteServiceTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import Pango
+
+@Suite("Pangolin site service", .serialized)
+struct PangolinSiteServiceTests {
+    private func makeService() throws -> PangolinSiteService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        let client = PangolinAPIClient(
+            configuration: try PangolinAPIConfiguration(
+                baseURLString: "https://api.example.com",
+                apiKey: "synthetic-key"
+            ),
+            session: URLSession(configuration: configuration)
+        )
+        return PangolinSiteService(client: client, organizationId: "synthetic-org")
+    }
+
+    @Test("lists sites using the current paginated response")
+    func listsSites() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.absoluteString == "https://api.example.com/v1/org/synthetic-org/sites?pageSize=100&page=1")
+            return .init(
+                statusCode: 200,
+                data: Data(#"{"data":{"sites":[{"siteId":7,"niceId":"lab","name":"Lab","pubKey":null,"subnet":null,"megabytesIn":12.5,"megabytesOut":3.25,"orgName":"Synthetic","type":"newt","online":false,"address":"100.89.0.2/24","newtVersion":"1.5.0","exitNodeId":2,"exitNodeName":"Region","exitNodeEndpoint":"example.com","remoteExitNodeId":null,"resourceCount":4,"status":"approved","newtUpdateAvailable":false,"labels":[]}],"pagination":{"total":1,"pageSize":100,"page":1}},"success":true,"error":false,"message":"Sites retrieved successfully","status":200}"#.utf8)
+            )
+        }
+
+        let page = try await makeService().listSites()
+
+        #expect(page.sites == [Site(siteId: 7, niceId: "lab", name: "Lab", pubKey: nil, subnet: nil, megabytesIn: 12.5, megabytesOut: 3.25, orgName: "Synthetic", type: "newt", online: false, address: "100.89.0.2/24", newtVersion: "1.5.0", newtUpdateAvailable: false, uptimePercent: nil, pending: nil, exitNodeId: 2, exitNodeName: "Region", exitNodeEndpoint: "example.com", remoteExitNodeId: nil, resourceCount: 4, status: "approved", newtId: nil, secret: nil)])
+        #expect(page.pagination.total == 1)
+    }
+
+    @Test("creates a Newt site and returns its one-time credentials")
+    func createsNewtSite() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.path == "/v1/org/synthetic-org/site")
+            #expect(request.httpMethod == "PUT")
+            let body = try #require(request.bodyData)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json["name"] as? String == "New Lab")
+            #expect(json["type"] as? String == "newt")
+            #expect(json.count == 2)
+            return .init(
+                statusCode: 201,
+                data: Data(#"{"data":{"siteId":8,"niceId":"new-lab","name":"New Lab","orgId":"synthetic-org","type":"newt","status":"approved","newtId":"newt-id","secret":"one-time-secret"},"success":true,"error":false,"message":"Site created successfully","status":201}"#.utf8)
+            )
+        }
+
+        let created = try await makeService().createNewtSite(name: "New Lab")
+
+        #expect(created.site.name == "New Lab")
+        #expect(created.credentials == SiteCredentials(id: "newt-id", secret: "one-time-secret"))
+    }
+
+    @Test("gets complete site details by numeric identifier")
+    func getsSiteDetails() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.path == "/v1/site/7")
+            #expect(request.httpMethod == "GET")
+            return .init(
+                statusCode: 200,
+                data: Data(#"{"data":{"siteId":7,"niceId":"lab","name":"Lab","orgId":"synthetic-org","type":"newt","status":"approved","online":true,"newtId":"newt-id","newtVersion":"1.5.0","countryCode":"US"},"success":true,"error":false,"message":"Site retrieved successfully","status":200}"#.utf8)
+            )
+        }
+
+        let site = try await makeService().getSite(siteId: 7)
+
+        #expect(site.siteId == 7)
+        #expect(site.newtId == "newt-id")
+    }
+
+    @Test("renames a site without changing unrelated settings")
+    func renamesSite() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.path == "/v1/site/8")
+            #expect(request.httpMethod == "POST")
+            let body = try #require(request.bodyData)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json as? [String: String] == ["name": "Renamed Lab"])
+            return .init(
+                statusCode: 200,
+                data: Data(#"{"data":{"siteId":8,"niceId":"new-lab","name":"Renamed Lab","orgId":"synthetic-org","type":"newt","status":"approved"},"success":true,"error":false,"message":"Site updated successfully","status":200}"#.utf8)
+            )
+        }
+
+        let site = try await makeService().renameSite(siteId: 8, name: "Renamed Lab")
+
+        #expect(site.name == "Renamed Lab")
+    }
+
+    @Test("deletes a site without deleting associated resources")
+    func deletesSiteSafely() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.absoluteString == "https://api.example.com/v1/site/8?deleteResources=false")
+            #expect(request.httpMethod == "DELETE")
+            return .init(
+                statusCode: 200,
+                data: Data(#"{"data":null,"success":true,"error":false,"message":"Site deleted successfully","status":200}"#.utf8)
+            )
+        }
+
+        try await makeService().deleteSite(siteId: 8)
+    }
+}
+
+private extension URLRequest {
+    var bodyData: Data? {
+        if let httpBody {
+            return httpBody
+        }
+        guard let httpBodyStream else {
+            return nil
+        }
+        httpBodyStream.open()
+        defer { httpBodyStream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1_024)
+        defer { buffer.deallocate() }
+        while httpBodyStream.hasBytesAvailable {
+            let count = httpBodyStream.read(buffer, maxLength: 1_024)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}


### PR DESCRIPTION
## Summary
- Add typed Pangolin site listing, details, creation, rename, and safe deletion.
- Show protected one-time Newt credentials after site creation.
- Add focused API tests and localized UI.