### PR TITLE
Add Pangolin public resource lifecycle

### DIFF
--- a/Pango/Helpers/API/PangolinPublicResourceService.swift
+++ b/Pango/Helpers/API/PangolinPublicResourceService.swift
@@ -47,6 +47,29 @@ struct PangolinPublicResourceService: Sendable {
         return try response.requiredData()
     }
 
+    func listAllResources(pageSize: Int = ResourcePagination.pageSize) async throws -> [Resource] {
+        var resources: [Resource] = []
+        var requestedPage = 1
+
+        while true {
+            let result = try await listResources(page: requestedPage, pageSize: pageSize)
+            resources.append(contentsOf: result.resources)
+
+            guard result.pagination.pageSize > 0,
+                  ResourcePagination.hasNextPage(
+                    total: result.pagination.total,
+                    page: result.pagination.page,
+                    pageSize: result.pagination.pageSize
+                  ) else {
+                return resources
+            }
+
+            let nextPage = result.pagination.page + 1
+            guard nextPage > requestedPage else { throw PangolinAPIError.decoding }
+            requestedPage = nextPage
+        }
+    }
+
     func createHTTP(name: String, subdomain: String, domainId: String) async throws -> Resource {
         let response: PangolinResponse<Resource> = try await client.send(
             .put,

--- a/Pango/Helpers/API/PangolinPublicResourceService.swift
+++ b/Pango/Helpers/API/PangolinPublicResourceService.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct PublicResourcesPage: Decodable {
+    let resources: [Resource]
+    let pagination: Pagination
+}
+
+enum PublicResourceRawProtocol: String, Encodable {
+    case tcp
+    case udp
+}
+
+struct PangolinPublicResourceService: Sendable {
+    private struct HTTPBody: Encodable {
+        let name: String
+        let subdomain: String
+        let domainId: String
+        let mode = "http"
+    }
+
+    private struct RawBody: Encodable {
+        let name: String
+        let mode: PublicResourceRawProtocol
+        let proxyPort: Int
+    }
+
+    private struct UpdateBody: Encodable {
+        let name: String?
+        let enabled: Bool?
+        let ssl: Bool?
+    }
+
+    private let client: PangolinAPIClient
+    private let organizationId: String
+
+    init(client: PangolinAPIClient, organizationId: String) {
+        self.client = client
+        self.organizationId = organizationId
+    }
+
+    func listResources(page: Int = 1, pageSize: Int = 100) async throws -> PublicResourcesPage {
+        let response: PangolinResponse<PublicResourcesPage> = try await client.send(
+            .get,
+            path: "/org/\(organizationId)/public-resources",
+            queryItems: [URLQueryItem(name: "pageSize", value: String(pageSize)), URLQueryItem(name: "page", value: String(page))]
+        )
+        return try response.requiredData()
+    }
+
+    func createHTTP(name: String, subdomain: String, domainId: String) async throws -> Resource {
+        let response: PangolinResponse<Resource> = try await client.send(
+            .put,
+            path: "/org/\(organizationId)/public-resource",
+            body: HTTPBody(name: name, subdomain: subdomain, domainId: domainId)
+        )
+        return try response.requiredData()
+    }
+
+    func createRaw(name: String, protocol rawProtocol: PublicResourceRawProtocol, proxyPort: Int) async throws -> Resource {
+        guard (1...65_535).contains(proxyPort) else {
+            throw PangolinAPIError.serverRejected(status: 400, message: "INVALID_PORT")
+        }
+        let response: PangolinResponse<Resource> = try await client.send(
+            .put,
+            path: "/org/\(organizationId)/public-resource",
+            body: RawBody(name: name, mode: rawProtocol, proxyPort: proxyPort)
+        )
+        return try response.requiredData()
+    }
+
+    func update(resourceId: Int, name: String? = nil, enabled: Bool? = nil, ssl: Bool? = nil) async throws -> Resource {
+        let response: PangolinResponse<Resource> = try await client.send(
+            .post,
+            path: "/public-resource/\(resourceId)",
+            body: UpdateBody(name: name, enabled: enabled, ssl: ssl)
+        )
+        return try response.requiredData()
+    }
+
+    func delete(resourceId: Int) async throws {
+        let response: PangolinResponse<PangolinEmptyResponse> = try await client.send(.delete, path: "/public-resource/\(resourceId)")
+        guard response.success, !response.error else {
+            throw PangolinAPIError.serverRejected(status: response.status, message: response.message)
+        }
+    }
+}
+
+private extension PangolinResponse {
+    func requiredData() throws -> Value {
+        guard success, !error else {
+            throw PangolinAPIError.serverRejected(status: status, message: message)
+        }
+        guard let data else { throw PangolinAPIError.decoding }
+        return data
+    }
+}

--- a/Pango/Helpers/AppService.swift
+++ b/Pango/Helpers/AppService.swift
@@ -96,9 +96,44 @@ class AppService: ObservableObject {
     }
     
     public func fetchResources() {
-        ResourcesRequest.fetch { success, resources in
-            self.resources = resources
+        Task {
+            _ = try? await fetchResources()
         }
+    }
+
+    public func fetchResources() async throws -> [Resource] {
+        let page = try await publicResourceService().listResources()
+        resources = page.resources
+        return page.resources
+    }
+
+    public func createHTTPResource(name: String, subdomain: String, domainId: String) async throws {
+        resources.append(try await publicResourceService().createHTTP(name: name, subdomain: subdomain, domainId: domainId))
+    }
+
+    public func createRawResource(name: String, protocol rawProtocol: PublicResourceRawProtocol, proxyPort: Int) async throws {
+        resources.append(try await publicResourceService().createRaw(name: name, protocol: rawProtocol, proxyPort: proxyPort))
+    }
+
+    public func updateResource(resourceId: Int, name: String? = nil, enabled: Bool? = nil, ssl: Bool? = nil) async throws -> Resource {
+        let resource = try await publicResourceService().update(resourceId: resourceId, name: name, enabled: enabled, ssl: ssl)
+        if let index = resources.firstIndex(where: { $0.resourceId == resourceId }) { resources[index] = resource }
+        return resource
+    }
+
+    public func deleteResource(resourceId: Int) async throws {
+        try await publicResourceService().delete(resourceId: resourceId)
+        resources.removeAll { $0.resourceId == resourceId }
+    }
+
+    private func publicResourceService() throws -> PangolinPublicResourceService {
+        let configuration: PangolinAPIConfiguration
+        do {
+            configuration = try PangolinAPIConfiguration(baseURLString: pangolinServerUrl, apiKey: pangolinApiKey)
+        } catch PangolinAPIConfiguration.Error.invalidBaseURL { throw PangolinAPIError.invalidBaseURL
+        } catch PangolinAPIConfiguration.Error.missingAPIKey { throw PangolinAPIError.missingAPIKey }
+        guard !pangolinOrganizationId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { throw PangolinAPIError.organizationRequired }
+        return PangolinPublicResourceService(client: PangolinAPIClient(configuration: configuration), organizationId: pangolinOrganizationId)
     }
     
     public func fetchDomains() {

--- a/Pango/Helpers/AppService.swift
+++ b/Pango/Helpers/AppService.swift
@@ -97,14 +97,18 @@ class AppService: ObservableObject {
     
     public func fetchResources() {
         Task {
-            _ = try? await fetchResources()
+            do {
+                _ = try await fetchResources()
+            } catch {
+                resources = []
+            }
         }
     }
 
     public func fetchResources() async throws -> [Resource] {
-        let page = try await publicResourceService().listResources()
-        resources = page.resources
-        return page.resources
+        let fetchedResources = try await publicResourceService().listAllResources()
+        resources = fetchedResources
+        return fetchedResources
     }
 
     public func createHTTPResource(name: String, subdomain: String, domainId: String) async throws {

--- a/Pango/Models/Resource.swift
+++ b/Pango/Models/Resource.swift
@@ -84,11 +84,11 @@ extension Resource {
 
 private extension KeyedDecodingContainer where Key == Resource.CodingKeys {
     func decodeIntOrBoolIfPresent(forKey key: Key) throws -> Int? {
-        if let value = try decodeIfPresent(Int.self, forKey: key) {
+        if let value = try? decodeIfPresent(Int.self, forKey: key) {
             return value
         }
 
-        if let value = try decodeIfPresent(Bool.self, forKey: key) {
+        if let value = try? decodeIfPresent(Bool.self, forKey: key) {
             return value ? 1 : 0
         }
 

--- a/Pango/Views/ResourceNameView.swift
+++ b/Pango/Views/ResourceNameView.swift
@@ -15,6 +15,7 @@ struct ResourceNameView: View {
     var resource: Resource
     
     @State private var name: String = ""
+    @State private var errorKey: String?
     
     var body: some View {
         Form {
@@ -36,15 +37,24 @@ struct ResourceNameView: View {
 
             }
         }
+        .alert("ERROR", isPresented: Binding(get: { errorKey != nil }, set: { if !$0 { errorKey = nil } })) {
+            Button("OK", role: .cancel) { errorKey = nil }
+        } message: {
+            if let errorKey { Text(LocalizedStringKey(errorKey)) }
+        }
     }
     
     private func save() {
         if self.name.isEmpty { return }
         
-        ResourcesRequest.updateName(id: self.resource.resourceId, name: self.name) { success, response in
-            if let res = response, res.success {
-                self.appService.fetchResources()
+        Task {
+            do {
+                _ = try await appService.updateResource(resourceId: resource.resourceId, name: name)
                 self.dismiss()
+            } catch let error as PangolinAPIError {
+                errorKey = error.localizationKey
+            } catch {
+                errorKey = "ERROR_CONNECTING_TO_SERVER"
             }
         }
     }

--- a/Pango/Views/ResourceView.swift
+++ b/Pango/Views/ResourceView.swift
@@ -12,10 +12,11 @@ struct ResourceView: View {
     @EnvironmentObject var appService: AppService
     @Environment(\.dismiss) var dismiss
     
-    var resource: Resource
+    @State var resource: Resource
     
     @State private var ssl: Bool = false
     @State private var showDeleteConfirmation: Bool = false
+    @State private var errorKey: String?
     
     var body: some View {
         List {
@@ -72,30 +73,42 @@ struct ResourceView: View {
                 }
             }
         }
+        .alert("ERROR", isPresented: Binding(get: { errorKey != nil }, set: { if !$0 { errorKey = nil } })) {
+            Button("OK", role: .cancel) { errorKey = nil }
+        } message: {
+            if let errorKey { Text(LocalizedStringKey(errorKey)) }
+        }
     }
     
     private func toggleStatus() {
-        ResourcesRequest.toggleStatus(id: self.resource.resourceId, enabled: !self.resource.enabled) { success, response in
-            if let res = response {
-                print(res.message)
+        Task {
+            do {
+                let updated = try await appService.updateResource(resourceId: resource.resourceId, enabled: !resource.enabled)
+                resource = updated
+            } catch let error as PangolinAPIError {
+                errorKey = error.localizationKey
             }
-            self.appService.fetchResources()
         }
     }
     
     private func toggleSSL() {
-        ResourcesRequest.toggleSSL(id: self.resource.resourceId, ssl: self.ssl) { success, response in
-            if let res = response, res.success {
-                self.appService.fetchResources()
+        Task {
+            do {
+                resource = try await appService.updateResource(resourceId: resource.resourceId, ssl: ssl)
+            } catch let error as PangolinAPIError {
+                errorKey = error.localizationKey
+                ssl = resource.ssl
             }
         }
     }
     
     private func delete() {
-        ResourcesRequest.delete(id: self.resource.resourceId) { success, response in
-            if let res = response, res.success {
-                self.appService.fetchResources()
+        Task {
+            do {
+                try await appService.deleteResource(resourceId: resource.resourceId)
                 self.dismiss()
+            } catch let error as PangolinAPIError {
+                errorKey = error.localizationKey
             }
         }
     }

--- a/Pango/Views/ResourcesCreateView.swift
+++ b/Pango/Views/ResourcesCreateView.swift
@@ -70,20 +70,18 @@ struct ResourcesCreateView: View {
     }
     
     private func save() {
-        ResourcesRequest.create(
-            name: self.name,
-            http: self.resourceHttp,
-            subdomain: self.subdomain,
-            domainId: self.selectedDomain.isEmpty ? nil : self.selectedDomain,
-            protocolString: self.protocolString,
-            proxyPort: self.proxyPort.isEmpty ? nil : Int(self.proxyPort)
-        ) { success, response in
-            if success {
-                self.dismiss()
-            } else {
-                if let msg = response?.message {
-                    self.errorMessage = msg
+        Task {
+            do {
+                if resourceHttp {
+                    try await appService.createHTTPResource(name: name, subdomain: subdomain, domainId: selectedDomain)
+                } else if let port = Int(proxyPort), let rawProtocol = PublicResourceRawProtocol(rawValue: protocolString) {
+                    try await appService.createRawResource(name: name, protocol: rawProtocol, proxyPort: port)
+                } else {
+                    throw PangolinAPIError.serverRejected(status: 400, message: "INVALID_PORT")
                 }
+                dismiss()
+            } catch let error as PangolinAPIError {
+                errorMessage = String(localized: String.LocalizationValue(error.localizationKey))
             }
         }
     }

--- a/PangoTests/API/PangolinPublicResourceServiceTests.swift
+++ b/PangoTests/API/PangolinPublicResourceServiceTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import Pango
+
+@Suite("Pangolin public resource service", .serialized)
+struct PangolinPublicResourceServiceTests {
+    private func makeService() throws -> PangolinPublicResourceService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        return PangolinPublicResourceService(
+            client: PangolinAPIClient(
+                configuration: try PangolinAPIConfiguration(baseURLString: "https://api.example.com", apiKey: "synthetic-key"),
+                session: URLSession(configuration: configuration)
+            ),
+            organizationId: "synthetic-org"
+        )
+    }
+
+    @Test("lists current public resources")
+    func listsResources() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.absoluteString == "https://api.example.com/v1/org/synthetic-org/public-resources?pageSize=100&page=1")
+            return .init(statusCode: 200, data: Data(#"{"data":{"resources":[{"resourceId":4,"name":"Web","ssl":true,"fullDomain":"web.example.com","sso":false,"http":true,"protocol":"tcp","enabled":true,"wildcard":false,"mode":"http","health":"unknown"}],"pagination":{"total":1,"pageSize":100,"page":1}},"success":true,"error":false,"message":"","status":200}"#.utf8))
+        }
+        let page = try await makeService().listResources()
+        #expect(page.resources.first?.name == "Web")
+        #expect(page.pagination.total == 1)
+    }
+
+    @Test("creates an HTTP resource using the current mode field")
+    func createsHTTPResource() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.path == "/v1/org/synthetic-org/public-resource")
+            #expect(request.httpMethod == "PUT")
+            let body = try #require(request.bodyData)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json["name"] as? String == "Web")
+            #expect(json["mode"] as? String == "http")
+            #expect(json["domainId"] as? String == "domain-id")
+            #expect(json["subdomain"] as? String == "web")
+            return .init(statusCode: 201, data: Self.resourceResponse(name: "Web"))
+        }
+        let resource = try await makeService().createHTTP(name: "Web", subdomain: "web", domainId: "domain-id")
+        #expect(resource.name == "Web")
+    }
+
+    @Test("creates a TCP resource with a validated proxy port")
+    func createsTCPResource() async throws {
+        URLProtocolStub.handler = { request in
+            let body = try #require(request.bodyData)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json["mode"] as? String == "tcp")
+            #expect(json["proxyPort"] as? Int == 2200)
+            return .init(statusCode: 201, data: Self.resourceResponse(name: "SSH Port", mode: "tcp", http: false))
+        }
+        let resource = try await makeService().createRaw(name: "SSH Port", protocol: .tcp, proxyPort: 2200)
+        #expect(resource.mode == "tcp")
+    }
+
+    @Test("updates only lifecycle fields")
+    func updatesResource() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.path == "/v1/public-resource/4")
+            #expect(request.httpMethod == "POST")
+            let body = try #require(request.bodyData)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json as? [String: AnyHashable] == ["name": "Renamed", "enabled": false])
+            return .init(statusCode: 200, data: Self.resourceResponse(name: "Renamed", enabled: false))
+        }
+        let resource = try await makeService().update(resourceId: 4, name: "Renamed", enabled: false)
+        #expect(!resource.enabled)
+    }
+
+    @Test("deletes through the non-legacy public resource route")
+    func deletesResource() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.path == "/v1/public-resource/4")
+            #expect(request.httpMethod == "DELETE")
+            return .init(statusCode: 200, data: Data(#"{"data":null,"success":true,"error":false,"message":"","status":200}"#.utf8))
+        }
+        try await makeService().delete(resourceId: 4)
+    }
+
+    private static func resourceResponse(name: String, mode: String = "http", http: Bool = true, enabled: Bool = true) -> Data {
+        Data("{\"data\":{\"resourceId\":4,\"name\":\"\(name)\",\"ssl\":false,\"sso\":false,\"http\":\(http),\"protocol\":\"tcp\",\"enabled\":\(enabled),\"wildcard\":false,\"mode\":\"\(mode)\",\"health\":\"unknown\"},\"success\":true,\"error\":false,\"message\":\"\",\"status\":200}".utf8)
+    }
+}
+
+private extension URLRequest {
+    var bodyData: Data? {
+        if let httpBody { return httpBody }
+        guard let httpBodyStream else { return nil }
+        httpBodyStream.open()
+        defer { httpBodyStream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1_024)
+        defer { buffer.deallocate() }
+        while httpBodyStream.hasBytesAvailable {
+            let count = httpBodyStream.read(buffer, maxLength: 1_024)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}

--- a/PangoTests/API/PangolinPublicResourceServiceTests.swift
+++ b/PangoTests/API/PangolinPublicResourceServiceTests.swift
@@ -27,6 +27,30 @@ struct PangolinPublicResourceServiceTests {
         #expect(page.pagination.total == 1)
     }
 
+    @Test("lists all public resource pages")
+    func listsAllResources() async throws {
+        URLProtocolStub.handler = { request in
+            let url = try #require(request.url)
+            let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+            let page = try #require(components.queryItems?.first(where: { $0.name == "page" })?.value)
+
+            if page == "1" {
+                return .init(
+                    statusCode: 200,
+                    data: Self.resourcesResponse(names: ["First", "Second"], total: 3, pageSize: 2, page: 1)
+                )
+            }
+            return .init(
+                statusCode: 200,
+                data: Self.resourcesResponse(names: ["Third"], total: 3, pageSize: 2, page: 2)
+            )
+        }
+
+        let resources = try await makeService().listAllResources(pageSize: 2)
+
+        #expect(resources.map(\.name) == ["First", "Second", "Third"])
+    }
+
     @Test("creates an HTTP resource using the current mode field")
     func createsHTTPResource() async throws {
         URLProtocolStub.handler = { request in
@@ -83,6 +107,13 @@ struct PangolinPublicResourceServiceTests {
 
     private static func resourceResponse(name: String, mode: String = "http", http: Bool = true, enabled: Bool = true) -> Data {
         Data("{\"data\":{\"resourceId\":4,\"name\":\"\(name)\",\"ssl\":false,\"sso\":false,\"http\":\(http),\"protocol\":\"tcp\",\"enabled\":\(enabled),\"wildcard\":false,\"mode\":\"\(mode)\",\"health\":\"unknown\"},\"success\":true,\"error\":false,\"message\":\"\",\"status\":200}".utf8)
+    }
+
+    private static func resourcesResponse(names: [String], total: Int, pageSize: Int, page: Int) -> Data {
+        let resources = names.enumerated().map { index, name in
+            "{\"resourceId\":\(page * 10 + index),\"name\":\"\(name)\",\"ssl\":false,\"sso\":false,\"http\":true,\"protocol\":\"tcp\",\"enabled\":true,\"wildcard\":false,\"mode\":\"http\",\"health\":\"unknown\"}"
+        }.joined(separator: ",")
+        return Data("{\"data\":{\"resources\":[\(resources)],\"pagination\":{\"total\":\(total),\"pageSize\":\(pageSize),\"page\":\(page)}},\"success\":true,\"error\":false,\"message\":\"\",\"status\":200}".utf8)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add typed public-resource list, create, update, enable/disable, and delete operations.
- Migrate the existing public-resource lifecycle UI to the new API service.
- Add focused request and decoding tests.