### PR TITLE
Add Local site creation

### DIFF
--- a/Pango/Helpers/API/PangolinSiteService.swift
+++ b/Pango/Helpers/API/PangolinSiteService.swift
@@ -12,13 +12,20 @@ struct SiteCredentials: Equatable {
 
 struct CreatedSite: Equatable {
     let site: Site
-    let credentials: SiteCredentials
+    let credentials: SiteCredentials?
+}
+
+enum SiteType: String, Encodable, CaseIterable, Identifiable {
+    case newt
+    case local
+
+    var id: String { rawValue }
 }
 
 struct PangolinSiteService: Sendable {
     private struct CreateSiteBody: Encodable {
         let name: String
-        let type = "newt"
+        let type: SiteType
     }
 
     private struct RenameSiteBody: Encodable {
@@ -46,16 +53,26 @@ struct PangolinSiteService: Sendable {
     }
 
     func createNewtSite(name: String) async throws -> CreatedSite {
+        let created = try await createSite(name: name, type: .newt)
+        guard created.credentials != nil else { throw PangolinAPIError.decoding }
+        return created
+    }
+
+    func createSite(name: String, type: SiteType) async throws -> CreatedSite {
         let response: PangolinResponse<Site> = try await client.send(
             .put,
             path: "/org/\(organizationId)/site",
-            body: CreateSiteBody(name: name)
+            body: CreateSiteBody(name: name, type: type)
         )
         let site = try response.requireData()
-        guard let id = site.newtId, let secret = site.secret else {
-            throw PangolinAPIError.decoding
+        let credentials: SiteCredentials?
+        if type == .newt {
+            guard let id = site.newtId, let secret = site.secret else { throw PangolinAPIError.decoding }
+            credentials = SiteCredentials(id: id, secret: secret)
+        } else {
+            credentials = nil
         }
-        return CreatedSite(site: site, credentials: SiteCredentials(id: id, secret: secret))
+        return CreatedSite(site: site, credentials: credentials)
     }
 
     func getSite(siteId: Int) async throws -> Site {

--- a/Pango/Helpers/AppService.swift
+++ b/Pango/Helpers/AppService.swift
@@ -50,7 +50,11 @@ class AppService: ObservableObject {
     }
 
     public func createNewtSite(name: String) async throws -> CreatedSite {
-        let created = try await siteService().createNewtSite(name: name)
+        try await createSite(name: name, type: .newt)
+    }
+
+    public func createSite(name: String, type: SiteType) async throws -> CreatedSite {
+        let created = try await siteService().createSite(name: name, type: type)
         var site = created.site
         site.secret = nil
         sites.append(site)

--- a/Pango/Localizable.xcstrings
+++ b/Pango/Localizable.xcstrings
@@ -70,6 +70,12 @@
     "abc123" : {
 
     },
+    "LOCAL" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Local" } },
+        "es-419" : { "stringUnit" : { "state" : "translated", "value" : "Local" } }
+      }
+    },
     "COPY" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy" } },

--- a/Pango/Views/SiteCreateView.swift
+++ b/Pango/Views/SiteCreateView.swift
@@ -7,6 +7,7 @@ struct SiteCreateView: View {
     @EnvironmentObject private var appService: AppService
     @State private var name = ""
     @State private var isSaving = false
+    @State private var siteType: SiteType = .newt
     @State private var credentials: SiteCredentials?
     @State private var errorKey: String?
 
@@ -25,7 +26,10 @@ struct SiteCreateView: View {
                 } else {
                     Section("SITE") {
                         TextField("NAME", text: $name)
-                        LabeledContent("TYPE", value: "Newt")
+                        Picker("TYPE", selection: $siteType) {
+                            Text("Newt").tag(SiteType.newt)
+                            Text("LOCAL").tag(SiteType.local)
+                        }
                     }
                 }
             }
@@ -74,7 +78,12 @@ struct SiteCreateView: View {
         Task {
             defer { isSaving = false }
             do {
-                credentials = try await appService.createNewtSite(name: trimmedName).credentials
+                let created = try await appService.createSite(name: trimmedName, type: siteType)
+                if let siteCredentials = created.credentials {
+                    credentials = siteCredentials
+                } else {
+                    dismiss()
+                }
             } catch let error as PangolinAPIError {
                 errorKey = error.localizationKey
             } catch {

--- a/Pango/Views/SiteCreateView.swift
+++ b/Pango/Views/SiteCreateView.swift
@@ -12,47 +12,44 @@ struct SiteCreateView: View {
     @State private var errorKey: String?
 
     var body: some View {
-        NavigationStack {
-            Form {
-                if let credentials {
-                    Section("SITE_CREDENTIALS") {
-                        credentialRow(title: "NEWT_ID", value: credentials.id)
-                        credentialRow(title: "SECRET", value: credentials.secret)
-                    }
-                    Section {
-                        Text("CREDENTIALS_ONE_TIME_WARNING")
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    Section("SITE") {
-                        TextField("NAME", text: $name)
-                        Picker("TYPE", selection: $siteType) {
-                            Text("Newt").tag(SiteType.newt)
-                            Text("LOCAL").tag(SiteType.local)
-                        }
+        Form {
+            if let credentials {
+                Section("SITE_CREDENTIALS") {
+                    credentialRow(title: "NEWT_ID", value: credentials.id)
+                    credentialRow(title: "SECRET", value: credentials.secret)
+                }
+                Section {
+                    Text("CREDENTIALS_ONE_TIME_WARNING")
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Section("SITE") {
+                    TextField("NAME", text: $name)
+                    Picker("TYPE", selection: $siteType) {
+                        Text("Newt").tag(SiteType.newt)
+                        Text("LOCAL").tag(SiteType.local)
                     }
                 }
             }
-            .navigationTitle(credentials == nil ? "CREATE_SITE" : "SITE_CREATED")
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(credentials == nil ? "CANCEL" : "DONE") { dismiss() }
-                }
+        }
+        .navigationTitle(credentials == nil ? "CREATE_SITE" : "SITE_CREATED")
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
                 if credentials == nil {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("CREATE") { create() }
-                            .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
-                    }
+                    Button("CREATE") { create() }
+                        .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
+                } else {
+                    Button("DONE") { dismiss() }
                 }
             }
-            .alert("ERROR", isPresented: Binding(
-                get: { errorKey != nil },
-                set: { if !$0 { errorKey = nil } }
-            )) {
-                Button("OK", role: .cancel) { errorKey = nil }
-            } message: {
-                if let errorKey { Text(LocalizedStringKey(errorKey)) }
-            }
+        }
+        .alert("ERROR", isPresented: Binding(
+            get: { errorKey != nil },
+            set: { if !$0 { errorKey = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorKey = nil }
+        } message: {
+            if let errorKey { Text(LocalizedStringKey(errorKey)) }
         }
     }
 

--- a/Pango/Views/SitesView.swift
+++ b/Pango/Views/SitesView.swift
@@ -16,7 +16,6 @@ struct SitesView: View {
 
     @EnvironmentObject var appService: AppService
     @State private var selectedSegment: SiteSegment = .all
-    @State private var isCreatingSite = false
     @State private var errorKey: String?
 
     var pendingSites: [Site] { appService.sites.filter { $0.status == "pending" || $0.pending == true } }
@@ -42,16 +41,13 @@ struct SitesView: View {
             .navigationTitle(Text("SITES"))
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        isCreatingSite = true
+                    NavigationLink {
+                        SiteCreateView()
+                            .environmentObject(appService)
                     } label: {
                         Label("CREATE_SITE", systemImage: "plus")
                     }
                 }
-            }
-            .sheet(isPresented: $isCreatingSite) {
-                SiteCreateView()
-                    .environmentObject(appService)
             }
             .alert("ERROR", isPresented: Binding(
                 get: { errorKey != nil },

--- a/PangoTests/API/PangolinSiteServiceTests.swift
+++ b/PangoTests/API/PangolinSiteServiceTests.swift
@@ -55,6 +55,28 @@ struct PangolinSiteServiceTests {
         #expect(created.credentials == SiteCredentials(id: "newt-id", secret: "one-time-secret"))
     }
 
+    @Test("creates a local site using only its name and type")
+    func createsLocalSite() async throws {
+        URLProtocolStub.handler = { request in
+            #expect(request.url?.path == "/v1/org/synthetic-org/site")
+            #expect(request.httpMethod == "PUT")
+            let body = try #require(request.bodyData)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json["name"] as? String == "On Server")
+            #expect(json["type"] as? String == "local")
+            #expect(json.count == 2)
+            return .init(
+                statusCode: 201,
+                data: Data(#"{"data":{"siteId":9,"niceId":"on-server","name":"On Server","orgId":"synthetic-org","type":"local","status":"approved","online":true},"success":true,"error":false,"message":"Site created successfully","status":201}"#.utf8)
+            )
+        }
+
+        let created = try await makeService().createSite(name: "On Server", type: .local)
+
+        #expect(created.site.type == "local")
+        #expect(created.credentials == nil)
+    }
+
     @Test("gets complete site details by numeric identifier")
     func getsSiteDetails() async throws {
         URLProtocolStub.handler = { request in


### PR DESCRIPTION
## Summary
- Add Local as a site creation option alongside Newt.
- Submit the minimal name and type payload required by Pangolin.
- Preserve one-time credential handling for Newt sites and add Local creation tests.